### PR TITLE
Fix/4 update footer

### DIFF
--- a/ckanext/idgotheme/templates/footer.html
+++ b/ckanext/idgotheme/templates/footer.html
@@ -37,7 +37,7 @@
       <div>
         <img src="{{ url_site_wp }}/wp-content/themes/crigepaca/assets/images/twitter.png" alt="twitter">
         <div>
-          <a href="https://twitter.com/openpaca?lang=fr" target="blank">@openpaca</a>
+          <a href="https://twitter.com/dataregionsud?lang=fr" target="blank">@dataregionsud</a>
           <a href="https://twitter.com/crigepaca?lang=fr" target="blank">@crigepaca</a>
         </div>
       </div>


### PR DESCRIPTION
Changement du compte tweeter dans le footer.
Le lien twitter de l’ancien compte @openpaca n'avait pas été actualisé avec le compte @dataregionsud